### PR TITLE
Fix duplicate primary key error when adding a wishlist

### DIFF
--- a/api/endpoints/student_wishlist.py
+++ b/api/endpoints/student_wishlist.py
@@ -31,11 +31,12 @@ class StudentWishlist(object):
 		floor = INT(request.params.get("floor"), nullable=True)
 
 		with sql(commit=True) as session:
-			wishlist = session.query(models.StudentWishlist).filter_by(student_id=self.student_id).all()
-
-			for value in wishlist:
-				if value.rank >= rank:
-					value.rank += 1
+			model = models.StudentWishlist
+			wishlist = session.query(model).filter(model.rank >= rank).filter_by(student_id=self.student_id).order_by(model.rank).all()
+			# manually commit.  We have to do this to avoid duplicate primary keys
+			for item in wishlist[::-1]:
+				item.rank += 1
+				session.commit()
 
 			item = models.StudentWishlist(student_id=self.student_id, rank=rank, dorm_id=dorm_id, room_id=room_id, floor=floor)
 			session.add(item)


### PR DESCRIPTION
Fixes an issue when adding an item to the wishlist.  When adding an item that is not at the end of the wishlist, we ran into a duplicate primary key error when updating the other items in the database.  With this change, we individually move each item instead of shifting them all at once.